### PR TITLE
Add Jest test for script paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "rags-to-robes",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/htmlScriptLinks.test.js
+++ b/tests/htmlScriptLinks.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+function getHtmlFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files = files.concat(getHtmlFiles(path.join(dir, entry.name)));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+describe('HTML script src paths', () => {
+  const htmlFiles = getHtmlFiles(path.resolve(__dirname, '..'));
+
+  htmlFiles.forEach((file) => {
+    test(`${path.relative(process.cwd(), file)} has valid script src references`, () => {
+      const html = fs.readFileSync(file, 'utf8');
+      const regex = /<script\s+[^>]*src=["']([^"']+)["'][^>]*>/gi;
+      let match;
+      while ((match = regex.exec(html)) !== null) {
+        const src = match[1];
+        if (/^https?:\/\//i.test(src) || src.startsWith('//')) {
+          continue; // external script, ignore
+        }
+        const resolved = path.resolve(path.dirname(file), src.split('?')[0]);
+        const exists = fs.existsSync(resolved);
+        expect(exists).toBe(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest-based test to ensure script tags reference existing files
- add `package.json` with Jest setup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddcd2ae208322a2efa975f62ac0c0